### PR TITLE
Fix CMake Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,29 @@ A Minecraft clone made in C++ and OpenGL
 
 ## How to Run
 To run the game, download the ScuffedMinecraft zip file from the [latest release](https://github.com/EvanatorM/ScuffedMinecraft/releases/latest), unzip the file, and run ScuffedMinecraft.exe. The assets folder must be in the same place as the exe file.
+
+## Building
+
+### Building with Visual Studio
+Import the project in Visual Studio 17 or higher and build it.
+
+### Building with CMake
+In the project root directory:
+Create CMake files:
+```sh
+mkdir -p build
+cd build
+cmake ../ScuffedMinecraft
+```
+After that you can build the project using:
+```sh
+cmake --build ./build
+```
+Run the build command in the project root directory.
+
+The final executable can be found at `(project root)/ScuffedMinecraft/bin`
+
+#### Note for building with CMake
+If you're running from a command line, make sure to run
+the executable in the same directory as it is located
+to ensure all resources are loaded properly.

--- a/ScuffedMinecraft/CMakeLists.txt
+++ b/ScuffedMinecraft/CMakeLists.txt
@@ -3,6 +3,19 @@ set(CMAKE_CXX_STANDARD 20)
 
 project(ScuffedMinecraft)
 
+# output directories
+set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+# copy assets
+add_custom_target(copy_assets ALL
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+  ${CMAKE_SOURCE_DIR}/assets
+  ${CMAKE_BINARY_DIR}/assets
+  COMMENT "Copying assets")
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_subdirectory(vendor/imgui)


### PR DESCRIPTION
this pr fixes foxmoss' cmake support:
* The final executable and libs now go in `(project root)/ScuffedMinecraft/bin`
* CMake build files and the final binary are now separated
* CMake script now copies resources over to the executable's folder so they can be loaded

also added cmake build instructions (please expand the VS build instructions if needed)