### PR TITLE
dirt under water level and denesting

### DIFF
--- a/ScuffedMinecraft/src/Application.cpp
+++ b/ScuffedMinecraft/src/Application.cpp
@@ -184,6 +184,57 @@ int main()
 	else
 	{
 		std::cout << "Failed to load texture\n";
+		// Use fallbacks
+		width = 256;
+		height = 256;
+		unsigned char* whiteTexture = new unsigned char[width * height * 4]; // RGBA
+		
+		int errorTexture = 1;  // 0 = white, 1 = checkerboard, 2 = colourful
+		
+		// Helper function to set RGBA values
+		auto setPixel = [](unsigned char* texture, int index, int r, int g, int b, int alpha) {
+			texture[index] = r;
+			texture[index + 1] = g;
+			texture[index + 2] = b;
+			texture[index + 3] = alpha;
+		};
+		
+		// Default to white
+		int r = 255, g = 255, b = 255;
+		
+		for (int y = 0; y < height; ++y)
+			{
+			int alpha = (y >= 64 && y < 96) ? 218 : 255; // Water transparency
+			
+			for (int x = 0; x < width; ++x)
+			{
+				if (errorTexture == 1)
+				{
+					// Checkerboard pattern
+					r = g = b = 0;
+					if ((x % 16 < 8) ^ (y % 16 < 8))
+						r = b = 255;
+				}
+				else if (errorTexture == 2)
+				{
+					// Colorful pattern, distinct color for each block
+					int spriteX = x / 16, spriteY = y / 16;
+					r = spriteX * 16;
+					g = spriteY * 16;
+					b = (spriteX + spriteY) * 8;
+				}
+				
+				int i = (y * width + x) * 4;
+				setPixel(whiteTexture, i, r, g, b, alpha);
+			}
+		}
+
+		// Upload the white texture
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, whiteTexture);
+		glGenerateMipmap(GL_TEXTURE_2D);
+
+		// Clean up
+		delete[] whiteTexture;
 	}
 
 	stbi_image_free(data);

--- a/ScuffedMinecraft/src/WorldGen.cpp
+++ b/ScuffedMinecraft/src/WorldGen.cpp
@@ -412,7 +412,7 @@ void WorldGen::GenerateChunkData(int chunkX, int chunkY, int chunkZ, int chunkSi
 				bool cave = false;
 				for (int i = 0; i < caveSettingsLength; i++)
 				{
-					if (noisecurrentY > caveSettings[i].maxHeight)
+					if (noiseY + startY > caveSettings[i].maxHeight)
 						continue;
 
 					float noiseCaves = noise3D.eval(

--- a/ScuffedMinecraft/src/WorldGen.cpp
+++ b/ScuffedMinecraft/src/WorldGen.cpp
@@ -375,7 +375,7 @@ void WorldGen::GenerateChunkData(int chunkX, int chunkY, int chunkZ, int chunkSi
 				if (blockSet)
 					continue;
 				
-				if (currentY == noiseY and noiseY < waterLevel)
+				if (currentY == noiseY and noiseY >= waterLevel)
 					chunkData->push_back(Blocks::GRASS_BLOCK);
 				else if (currentY > 10)
 					chunkData->push_back(Blocks::DIRT_BLOCK);

--- a/ScuffedMinecraft/src/WorldGen.cpp
+++ b/ScuffedMinecraft/src/WorldGen.cpp
@@ -338,16 +338,15 @@ void WorldGen::GenerateChunkData(int chunkX, int chunkY, int chunkZ, int chunkSi
 				}
 
 				// Step 1: Terrain Shape (surface and caves) and Ores
-				if (cave) {
-					// TODO: This is where cave stuff goes
-					chunkData->push_back(Blocks::AIR);
-					continue;
-				}
 				
 				if (currentY > noiseY and currentY <= waterLevel)
 				{
 					// TODO: This is where wet stuff goes
 					chunkData->push_back(Blocks::WATER);
+					continue;
+				} else if (cave) {
+					// TODO: This is where cave stuff goes
+					chunkData->push_back(Blocks::AIR);
 					continue;
 				}
 				

--- a/ScuffedMinecraft/src/WorldGen.cpp
+++ b/ScuffedMinecraft/src/WorldGen.cpp
@@ -347,7 +347,7 @@ void WorldGen::GenerateChunkData(int chunkX, int chunkY, int chunkZ, int chunkSi
 				if (currentY > noiseY and currentY <= waterLevel)
 					// TODO: This is where wet stuff goes
 					chunkData->push_back(Blocks::WATER);
-					continue
+					continue;
 				}
 				
 				// Ground

--- a/ScuffedMinecraft/src/WorldGen.cpp
+++ b/ScuffedMinecraft/src/WorldGen.cpp
@@ -310,14 +310,16 @@ void WorldGen::GenerateChunkData(int chunkX, int chunkY, int chunkZ, int chunkSi
 			{
 				// Cave noise
 				bool cave = false;
+				int currentY = y + startY;
+				
 				for (int i = 0; i < caveSettingsLength; i++)
 				{
-					if (y + startY > caveSettings[i].maxHeight)
+					if (currentY > caveSettings[i].maxHeight)
 						continue;
 
 					float noiseCaves = noise3D.eval(
 						(float)((x + startX) * caveSettings[i].frequency) + caveSettings[i].offset,
-						(float)((y + startY) * caveSettings[i].frequency) + caveSettings[i].offset,
+						(float)((currentY) * caveSettings[i].frequency) + caveSettings[i].offset,
 						(float)((z + startZ) * caveSettings[i].frequency) + caveSettings[i].offset)
 						* caveSettings[i].amplitude;
 
@@ -331,49 +333,49 @@ void WorldGen::GenerateChunkData(int chunkX, int chunkY, int chunkZ, int chunkSi
 				// Step 1: Terrain Shape (surface and caves) and Ores
 
 				// Sky and Caves
-				if (y + startY > noiseY)
+				if (currentY > noiseY)
 				{
-					if (y + startY <= waterLevel)
+					if (currentY <= waterLevel)
 						chunkData->push_back(Blocks::WATER);
 					else
 						chunkData->push_back(Blocks::AIR);
+					continue;
 				}
-				else if (cave)
+				else if (cave) {
 					chunkData->push_back(Blocks::AIR);
+					continue;
+				}
+				
 				// Ground
-				else
+				bool blockSet = false;
+				for (int i = 0; i < oreSettingsLength; i++)
 				{
-					bool blockSet = false;
-					for (int i = 0; i < oreSettingsLength; i++)
+					if (currentY > oreSettings[i].maxHeight)
+						continue;
+
+					float noiseOre = noise3D.eval(
+						(float)((x + startX) * oreSettings[i].frequency) + oreSettings[i].offset,
+						(float)((currentY) * oreSettings[i].frequency) + oreSettings[i].offset,
+						(float)((z + startZ) * oreSettings[i].frequency) + oreSettings[i].offset)
+						* oreSettings[i].amplitude;
+
+					if (noiseOre > oreSettings[i].chance)
 					{
-						if (y + startY > oreSettings[i].maxHeight)
-							continue;
-
-						float noiseOre = noise3D.eval(
-							(float)((x + startX) * oreSettings[i].frequency) + oreSettings[i].offset,
-							(float)((y + startY) * oreSettings[i].frequency) + oreSettings[i].offset,
-							(float)((z + startZ) * oreSettings[i].frequency) + oreSettings[i].offset)
-							* oreSettings[i].amplitude;
-
-						if (noiseOre > oreSettings[i].chance)
-						{
-							chunkData->push_back(oreSettings[i].block);
-							blockSet = true;
-							break;
-						}
-					}
-
-					if (!blockSet)
-					{
-						if (y + startY == noiseY and noiseY < waterLevel)
-							chunkData->push_back(Blocks::GRASS_BLOCK);
-						else if (y + startY > 10)
-							chunkData->push_back(Blocks::DIRT_BLOCK);
-						else
-							chunkData->push_back(Blocks::STONE_BLOCK);
+						chunkData->push_back(oreSettings[i].block);
+						blockSet = true;
+						break;
 					}
 				}
-			}
+
+				if (blockSet)
+					continue;
+				
+				if (currentY == noiseY and noiseY < waterLevel)
+					chunkData->push_back(Blocks::GRASS_BLOCK);
+				else if (currentY > 10)
+					chunkData->push_back(Blocks::DIRT_BLOCK);
+				else
+					chunkData->push_back(Blocks::STONE_BLOCK);
 		}
 	}
 
@@ -404,7 +406,7 @@ void WorldGen::GenerateChunkData(int chunkX, int chunkY, int chunkZ, int chunkSi
 				bool cave = false;
 				for (int i = 0; i < caveSettingsLength; i++)
 				{
-					if (noiseY + startY > caveSettings[i].maxHeight)
+					if (noisecurrentY > caveSettings[i].maxHeight)
 						continue;
 
 					float noiseCaves = noise3D.eval(

--- a/ScuffedMinecraft/src/WorldGen.cpp
+++ b/ScuffedMinecraft/src/WorldGen.cpp
@@ -345,6 +345,7 @@ void WorldGen::GenerateChunkData(int chunkX, int chunkY, int chunkZ, int chunkSi
 				}
 				
 				if (currentY > noiseY and currentY <= waterLevel)
+				{
 					// TODO: This is where wet stuff goes
 					chunkData->push_back(Blocks::WATER);
 					continue;
@@ -380,6 +381,7 @@ void WorldGen::GenerateChunkData(int chunkX, int chunkY, int chunkZ, int chunkSi
 					chunkData->push_back(Blocks::DIRT_BLOCK);
 				else
 					chunkData->push_back(Blocks::STONE_BLOCK);
+			}
 		}
 	}
 

--- a/ScuffedMinecraft/src/WorldGen.cpp
+++ b/ScuffedMinecraft/src/WorldGen.cpp
@@ -308,10 +308,17 @@ void WorldGen::GenerateChunkData(int chunkX, int chunkY, int chunkZ, int chunkSi
 
 			for (int y = 0; y < chunkSize; y++)
 			{
-				// Cave noise
-				bool cave = false;
 				int currentY = y + startY;
 				
+				if (currentY > noiseY and currentY > waterLevel)
+				{
+					// Sky is air, no need to process
+					chunkData->push_back(Blocks::AIR);
+					continue;
+				}
+				
+				// Cave noise
+				bool cave = false;
 				for (int i = 0; i < caveSettingsLength; i++)
 				{
 					if (currentY > caveSettings[i].maxHeight)
@@ -331,19 +338,16 @@ void WorldGen::GenerateChunkData(int chunkX, int chunkY, int chunkZ, int chunkSi
 				}
 
 				// Step 1: Terrain Shape (surface and caves) and Ores
-
-				// Sky and Caves
-				if (currentY > noiseY)
-				{
-					if (currentY <= waterLevel)
-						chunkData->push_back(Blocks::WATER);
-					else
-						chunkData->push_back(Blocks::AIR);
-					continue;
-				}
-				else if (cave) {
+				if (cave) {
+					// TODO: This is where cave stuff goes
 					chunkData->push_back(Blocks::AIR);
 					continue;
+				}
+				
+				if (currentY > noiseY and currentY <= waterLevel)
+					// TODO: This is where wet stuff goes
+					chunkData->push_back(Blocks::WATER);
+					continue
 				}
 				
 				// Ground

--- a/ScuffedMinecraft/src/WorldGen.cpp
+++ b/ScuffedMinecraft/src/WorldGen.cpp
@@ -365,7 +365,7 @@ void WorldGen::GenerateChunkData(int chunkX, int chunkY, int chunkZ, int chunkSi
 
 					if (!blockSet)
 					{
-						if (y + startY == noiseY)
+						if (y + startY == noiseY and noiseY < waterLevel)
 							chunkData->push_back(Blocks::GRASS_BLOCK);
 						else if (y + startY > 10)
 							chunkData->push_back(Blocks::DIRT_BLOCK);


### PR DESCRIPTION
3 changes

firstly check if we are placing the block below water level to avoid grass blocks underwater, should be dirt.

since absolute y value is checked a lot, makes it less prone to errors if you give it a variable so you don't have order of operation issues.

and then removing some indenting, guard clauses to end early rather than nesting else cases.

hope this works I don't even do c++
![spinning-fish](https://github.com/user-attachments/assets/de3a3946-4b0a-4134-903c-8297e0492789)
