### PR TITLE
fix "Selected Block" text display

### DIFF
--- a/ScuffedMinecraft/src/Application.cpp
+++ b/ScuffedMinecraft/src/Application.cpp
@@ -511,7 +511,7 @@ int main(int argc, char *argv[])
 			ImGui::Text("Chunks: %d (%d rendered)", Planet::planet->numChunks, Planet::planet->numChunksRendered);
 			ImGui::Text("Position: x: %f, y: %f, z: %f", camera.Position.x, camera.Position.y, camera.Position.z);
 			ImGui::Text("Direction: x: %f, y: %f, z: %f", camera.Front.x, camera.Front.y, camera.Front.z);
-			ImGui::Text("Selected Block: %s", Blocks::blocks[selectedBlock].blockName);
+			ImGui::Text("Selected Block: %s", Blocks::blocks[selectedBlock].blockName.c_str());
 			if (ImGui::SliderInt("Render Distance", &Planet::planet->renderDistance, 0, 30))
 				Planet::planet->ClearChunkQueue();
 			if (ImGui::SliderInt("Render Height", &Planet::planet->renderHeight, 0, 10))

--- a/ScuffedMinecraft/src/Blocks.h
+++ b/ScuffedMinecraft/src/Blocks.h
@@ -23,7 +23,7 @@ namespace Blocks
 
 		Block(0, 2, 1, 3, Block::LEAVES, "Leaves"),					// Leaves
 		Block(1, 2, 2, 3, Block::BILLBOARD, "Grass"),				// Grass
-		Block(3, 0, 4, 1, Block::BILLBOARD, "Tall Grass Bot"),		// Tall Grass Bottom
+		Block(3, 0, 4, 1, Block::BILLBOARD, "Tall Grass Bottom"),	// Tall Grass Bottom
 		Block(3, 1, 4, 2, Block::BILLBOARD, "Tall Grass Top"),		// Tall Grass Top
 		Block(0, 3, 1, 4, Block::BILLBOARD, "Poppy"),				// Poppy
 		Block(2, 2, 3, 3, Block::BILLBOARD, "White Tulip"),			// White Tulip


### PR DESCRIPTION
this fixes a bug in the `"Selected Block"` display where instead of the expected `char*` the `std::string` was passed to `ImGui::Text`
_also changes `Tall Grass Bot` to `Tall Grass Bottom` since that is working correctly now_

the reason this could still work in some situations _(for me in release but not debug)_ is that `std::string` uses "small string optimization" where small strings are stored in the object itself instead of being allocated elsewhere. if the layout of `std::string` happens to align in such a way that it could be interpreted like a `char[]` it will work, but only for small strings