### PR TITLE
Fixing crash when changing render distance

### DIFF
--- a/ScuffedMinecraft/src/Planet.cpp
+++ b/ScuffedMinecraft/src/Planet.cpp
@@ -103,9 +103,11 @@ void Planet::ChunkThreadUpdate()
 				chunks.find({ pos.x, pos.y, pos.z - 1 }) == chunks.end())
 			{
 				delete chunkData.at(pos);
-				chunkData.erase(pos);
+				it = chunkData.erase(it);
 			}
-			++it;
+			else {
+				++it;
+			}
 		}
 
 		// Check if camera moved to new chunk


### PR DESCRIPTION
This fixes a bug in Planet.cpp which caused crash when lowering the render distance.
As of my observations, it is fixed by this commit.
It was caused by deleting from a map which we were iterating through.
The crash is shown in this screenshot:
![image](https://github.com/user-attachments/assets/357a9e21-6427-4ff8-b5e8-41b63d0294d2)
And this is the call stack:

> ScuffedMinecraft.exe!std::_List_const_iterator<std::_List_val<std::_List_simple_types<std::pair<ChunkPos const ,ChunkData *>>>>::operator++() Line 160	C++
>  ScuffedMinecraft.exe!std::_List_iterator<std::_List_val<std::_List_simple_types<std::pair<ChunkPos const ,ChunkData *>>>>::operator++() Line 246	C++
> ScuffedMinecraft.exe!Planet::ChunkThreadUpdate() Line 108	C++
