### PR TITLE
Fix crash after pressing F1.

### DIFF
--- a/ScuffedMinecraft/src/Application.cpp
+++ b/ScuffedMinecraft/src/Application.cpp
@@ -518,10 +518,10 @@ int main(int argc, char *argv[])
 				Planet::planet->ClearChunkQueue();
 			ImGui::Checkbox("Use absolute Y axis for camera vertical movement", &camera.absoluteVerticalMovement);
 			ImGui::End();
-
-			ImGui::Render();
-			ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 		}
+
+		ImGui::Render();
+		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
 		// Check and call events and swap buffers
 		glfwSwapBuffers(window);


### PR DESCRIPTION
Moved `ImGui::Render();` to the main rendering loop for now so it'll always run and not accidentally abort when `uiEnabled` is false.
### Issue:

> ```
> scuffed_mc: /home/david/ScuffedMinecraft/ScuffedMinecraft/vendor/imgui/imgui.cpp:10090: void ImGui::ErrorCheckNewFrameSanityChecks(): Assertion `(g.FrameCount == 0 || g.FrameCountEnded == g.FrameCount) && "Forgot to call Render() or EndFrame() at the end of the previous frame?"' failed.
> 
> Thread 1 "scuffed_mc" received signal SIGABRT, Aborted.
> __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, 
>     no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
> 44	./nptl/pthread_kill.c: No such file or directory.
> ```