### PR TITLE
Changed logger to use localtime_r instead of localtime_s

### DIFF
--- a/WillowVoxEngine/include/WillowVox/core/Logger.h
+++ b/WillowVoxEngine/include/WillowVox/core/Logger.h
@@ -24,7 +24,7 @@ namespace WillowVox
 		{
 			std::time_t t = std::time(nullptr);
 			std::tm now;
-			localtime_s(&now, &t);
+			localtime_r(&t, &now);
 			printf(LOG_COLOR_RESET "[%d:%d:%d App] ", now.tm_hour, now.tm_min, now.tm_sec);
 			printf(msg, args...);
 			printf("\n");
@@ -44,7 +44,7 @@ namespace WillowVox
 		{
 			std::time_t t = std::time(nullptr);
 			std::tm now;
-			localtime_s(&now, &t);
+			localtime_r(&t, &now);
 			printf(LOG_COLOR_APP_WARN "[%d:%d:%d App] WARN: ", now.tm_hour, now.tm_min, now.tm_sec);
 			printf(msg, args...);
 			printf(LOG_COLOR_RESET "\n");
@@ -64,7 +64,7 @@ namespace WillowVox
 		{
 			std::time_t t = std::time(nullptr);
 			std::tm now;
-			localtime_s(&now, &t);
+			localtime_r(&t, &now);
 			printf(LOG_COLOR_APP_ERROR "[%d:%d:%d App] ERROR: ", now.tm_hour, now.tm_min, now.tm_sec);
 			printf(msg, args...);
 			printf(LOG_COLOR_RESET "\n");
@@ -85,7 +85,7 @@ namespace WillowVox
 		{
 			std::time_t t = std::time(nullptr);
 			std::tm now;
-			localtime_s(&now, &t);
+			localtime_r(&t, &now);
 			printf(LOG_COLOR_ENGINE_LOG "[%d:%d:%d Engine] ", now.tm_hour, now.tm_min, now.tm_sec);
 			printf(msg, args...);
 			printf(LOG_COLOR_RESET "\n");
@@ -105,7 +105,7 @@ namespace WillowVox
 		{
 			std::time_t t = std::time(nullptr);
 			std::tm now;
-			localtime_s(&now, &t);
+			localtime_r(&t, &now);
 			printf(LOG_COLOR_ENGINE_WARN "[%d:%d:%d Engine] WARN: ", now.tm_hour, now.tm_min, now.tm_sec);
 			printf(msg, args...);
 			printf(LOG_COLOR_RESET "\n");
@@ -125,7 +125,7 @@ namespace WillowVox
 		{
 			std::time_t t = std::time(nullptr);
 			std::tm now;
-			localtime_s(&now, &t);
+			localtime_r(&t, &now);
 			printf(LOG_COLOR_ENGINE_ERROR "[%d:%d:%d Engine] ERROR: ", now.tm_hour, now.tm_min, now.tm_sec);
 			printf(msg, args...);
 			printf(LOG_COLOR_RESET "\n");


### PR DESCRIPTION
Snippet from [my issue reply](https://github.com/EvanatorM/ScuffedMinecraft/issues/39) regarding this: 

"The original logger used the `localtime_s()` function, it complicated things and isn't really needed in this context as the security it adds isn't  needed here since the variables used in it are defined right above it. I changed the logger in `WillowVoxEngine/include/WillowVox/core/Logger.h` to use `localtime_r()` instead and since the `now` and `t`variables weren't in their proper places I swapped them around. The result was replacing every occurrence of `localtime_s(&now, &t)` to `localtime_r(&t, &now)`.
"

I am aware that this is supposed to go to the engines repo, but since it isn't a submodule here I opted to modify it here instead.