### PR TITLE
fix wrong type of abs() in block placement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ target_compile_definitions(ScuffedMinecraft
 if (MSVC)
     add_compile_options(/fsanitize=address /Zi /Od)
     add_link_options(/fsanitize=address)
+else()
+    target_compile_options(ScuffedMinecraft PRIVATE -Wall -Wextra)
 endif()
 
 # Copy assets folder to build folder

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@
 #include <wv/VoxelWorlds.h>
 #include <world/ScuffedWorldGen.h>
 #include <ui/UIManager.h>
-#include <cstdlib>
+#include <cmath>
 
 using namespace WillowVox;
 
@@ -138,9 +138,9 @@ namespace ScuffedMinecraft
                         int blockZ = block.z;
 
                         // Choose face to place on
-                        if (abs(distX) > abs(distY) && abs(distX) > abs(distZ))
+                        if (std::fabs(distX) > std::fabs(distY) && std::fabs(distX) > std::fabs(distZ))
                             blockX += (distX > 0 ? 1 : -1);
-                        else if (abs(distY) > abs(distX) && abs(distY) > abs(distZ))
+                        else if (std::fabs(distY) > std::fabs(distX) && std::fabs(distY) > std::fabs(distZ))
                             blockY += (distY > 0 ? 1 : -1);
                         else
                             blockZ += (distZ > 0 ? 1 : -1);


### PR DESCRIPTION
So block placement was behaving weirdly, they were always getting placed into the positive z direction no matter what.
I'm on linux, so I decided to add the usual warning flags to the cmake config and they helped me find the issue.
After that it warned me about incorrect type usage for abs(). abs is from C and is intended for use with integers, but distX and distY are floats, so I changed it to the correctly typed std::fabs(). 
This fixed the issue.
Weird that this wasn't a problem on Windows.